### PR TITLE
statik: add -f flag to override any existing statik.go

### DIFF
--- a/icon.go
+++ b/icon.go
@@ -1,6 +1,6 @@
 package draft
 
-//go:generate statik -p statik -src=./assets
+//go:generate statik -f -p statik -src=./assets
 
 import (
 	"fmt"

--- a/icon_test.go
+++ b/icon_test.go
@@ -1,6 +1,6 @@
 package draft
 
-//go:generate statik -p statik -src=./assets
+//go:generate statik -f -p statik -src=./assets
 
 import (
 	"fmt"

--- a/impl_test.go
+++ b/impl_test.go
@@ -1,6 +1,6 @@
 package draft
 
-//go:generate statik -p statik -src=./assets
+//go:generate statik -f -p statik -src=./assets
 
 import (
 	"testing"


### PR DESCRIPTION
The install instructions include a 'go generate' step, but it fails b/c the statik.go already exists:

```
vscode ➜ /workspace/cmd (fix_statik) $ go generate ../...
file "statik/statik.go" already exists; use -f to overwrite
../icon.go:3: running "statik": exit status 1
```

Not sure if you prefer to remove the step from the instructions, or add the -f flag per this PR. 

